### PR TITLE
feat: add circuit breaker pattern to gRPC clients

### DIFF
--- a/cmd/conductor/handler/flow.go
+++ b/cmd/conductor/handler/flow.go
@@ -41,11 +41,13 @@ func (h *Handler) Listen(ctx context.Context) {
 
 // processBatch establishes a gRPC stream with Spider and processes incoming pages
 func (h *Handler) processBatch(ctx context.Context) error {
-	// Establish streaming connection with Spider
-	stream, err := h.spiderClient.GetSeenList(ctx)
+	result, err := h.breaker.Execute(func() (interface{}, error) {
+		return h.spiderClient.GetSeenList(ctx)
+	})
 	if err != nil {
 		return err
 	}
+	stream := result.(spider.Spider_GetSeenListClient)
 
 	// Request pages from Spider
 	req := &spider.SeenListRequest{

--- a/cmd/conductor/handler/handler.go
+++ b/cmd/conductor/handler/handler.go
@@ -2,15 +2,19 @@ package handler
 
 import (
 	"context"
+	"time"
 	"webcrawler/cmd/spider/pkg/site"
 	"webcrawler/pkg/awsx/queue"
 	"webcrawler/pkg/generated/service/spider"
+
+	"github.com/sony/gobreaker"
 )
 
 type Handler struct {
 	siteI        SiteI
 	queue        queue.HandlerI
 	spiderClient spider.SpiderClient
+	breaker      *gobreaker.CircuitBreaker
 }
 
 type SiteI interface {
@@ -18,9 +22,18 @@ type SiteI interface {
 }
 
 func New(site SiteI, queue queue.HandlerI, sliderClient spider.SpiderClient) Handler {
+	cb := gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        "spider",
+		MaxRequests: 1,
+		Timeout:     60 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	})
 	return Handler{
 		queue:        queue,
 		siteI:        site,
 		spiderClient: sliderClient,
+		breaker:      cb,
 	}
 }

--- a/cmd/frontend/grpc/client.go
+++ b/cmd/frontend/grpc/client.go
@@ -6,14 +6,16 @@ import (
 	"time"
 	pb "webcrawler/pkg/generated/service/searcher"
 
+	"github.com/sony/gobreaker"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 // SearcherClient wraps the gRPC client for the Searcher service
 type SearcherClient struct {
-	conn   *grpc.ClientConn
-	client pb.SearcherClient
+	conn    *grpc.ClientConn
+	client  pb.SearcherClient
+	breaker *gobreaker.CircuitBreaker
 }
 
 // NewSearcherClient creates a new Searcher gRPC client
@@ -29,25 +31,35 @@ func NewSearcherClient(address string) (*SearcherClient, error) {
 		return nil, fmt.Errorf("failed to connect to searcher at %s: %w", address, err)
 	}
 
-	client := pb.NewSearcherClient(conn)
+	cb := gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        "searcher",
+		MaxRequests: 1,
+		Timeout:     60 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	})
 
 	return &SearcherClient{
-		conn:   conn,
-		client: client,
+		conn:    conn,
+		client:  pb.NewSearcherClient(conn),
+		breaker: cb,
 	}, nil
 }
 
 // Search performs a search query
 func (c *SearcherClient) Search(ctx context.Context, query string, limit, offset int32) (*pb.SearchResponse, error) {
-	resp, err := c.client.SearchPages(ctx, &pb.SearchRequest{
-		Query:  query,
-		Limit:  limit,
-		Offset: offset,
+	result, err := c.breaker.Execute(func() (interface{}, error) {
+		return c.client.SearchPages(ctx, &pb.SearchRequest{
+			Query:  query,
+			Limit:  limit,
+			Offset: offset,
+		})
 	})
 	if err != nil {
 		return nil, fmt.Errorf("search failed: %w", err)
 	}
-	return resp, nil
+	return result.(*pb.SearchResponse), nil
 }
 
 // CheckHealth checks if the Searcher service is healthy

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/sony/gobreaker v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0Zqm
 github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
+github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
## Summary
- Adds `github.com/sony/gobreaker` dependency
- Wraps `Spider.GetSeenList` in conductor with a circuit breaker (stored on `Handler`)
- Wraps `Searcher.SearchPages` in frontend with a circuit breaker (stored on `SearcherClient`)
- Configuration: opens after 3 consecutive failures, 60s recovery timeout, 1 request allowed in half-open state

## Test plan
- [ ] `go build ./cmd/conductor/... ./cmd/frontend/...` passes cleanly
- [ ] Manually verify circuit opens when Spider/Searcher is killed and recovers after 60s