### PR TITLE
feat: add structured logging to cartographer, searcher, and frontend

### DIFF
--- a/cmd/cartographer/handler/flow.go
+++ b/cmd/cartographer/handler/flow.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"log/slog"
 	"time"
 	"webcrawler/cmd/cartographer/pkg/fetch"
 	"webcrawler/cmd/cartographer/pkg/graph"
@@ -14,31 +15,43 @@ func (d *Handler) Traverse() error {
 	var graphs []graph.Graph
 	sweepName := time.Now().Format("pagerank_20060102_150405")
 
+	slog.Info("Starting PageRank traversal", slog.String("sweep", sweepName), slog.Int("sweepCount", d.sweepCount))
+
 	for i := 0; i < d.sweepCount; i++ {
 		metrics.Sweeps.Inc()
 		sites := fetch.Fetch(d.db, d.sweepBreath)
+		slog.Info("Processing sweep iteration",
+			slog.Int("iteration", i+1),
+			slog.Int("total", d.sweepCount),
+			slog.Int("siteCount", len(sites)))
+
 		g := graph.New(sites)
 		for range sites {
 			metrics.SitesProcessed.WithLabelValues().Inc()
 		}
 
-		// Use PageRank algorithm instead of simple Traverse
 		ranked, err := graph.PageRank(ctx, g)
 		if err != nil {
+			slog.Error("PageRank computation failed", slog.Int("iteration", i+1), slog.Any("error", err))
 			return err
 		}
 		graphs = append(graphs, ranked)
 	}
 
+	slog.Info("Merging PageRank graphs", slog.Int("graphCount", len(graphs)))
 	merged, err := graph.Merge(graphs)
 	if err != nil {
+		slog.Error("Failed to merge PageRank graphs", slog.Any("error", err))
 		return err
 	}
 
+	slog.Info("Pushing PageRank results", slog.String("sweep", sweepName))
 	err = push.Push(d.db, merged, sweepName, time.Now())
 	if err != nil {
+		slog.Error("Failed to push PageRank results", slog.String("sweep", sweepName), slog.Any("error", err))
 		return err
 	}
 
+	slog.Info("PageRank traversal completed successfully", slog.String("sweep", sweepName))
 	return nil
 }

--- a/cmd/frontend/grpc/client.go
+++ b/cmd/frontend/grpc/client.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 	pb "webcrawler/pkg/generated/service/searcher"
 
@@ -20,6 +21,8 @@ type SearcherClient struct {
 
 // NewSearcherClient creates a new Searcher gRPC client
 func NewSearcherClient(address string) (*SearcherClient, error) {
+	slog.Info("Connecting to Searcher service", slog.String("address", address))
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -28,6 +31,7 @@ func NewSearcherClient(address string) (*SearcherClient, error) {
 		grpc.WithBlock(),
 	)
 	if err != nil {
+		slog.Error("Failed to connect to Searcher service", slog.String("address", address), slog.Any("error", err))
 		return nil, fmt.Errorf("failed to connect to searcher at %s: %w", address, err)
 	}
 
@@ -38,8 +42,15 @@ func NewSearcherClient(address string) (*SearcherClient, error) {
 		ReadyToTrip: func(counts gobreaker.Counts) bool {
 			return counts.ConsecutiveFailures >= 3
 		},
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			slog.Warn("Circuit breaker state changed",
+				slog.String("breaker", name),
+				slog.String("from", from.String()),
+				slog.String("to", to.String()))
+		},
 	})
 
+	slog.Info("Searcher gRPC client initialized", slog.String("address", address))
 	return &SearcherClient{
 		conn:    conn,
 		client:  pb.NewSearcherClient(conn),
@@ -57,9 +68,12 @@ func (c *SearcherClient) Search(ctx context.Context, query string, limit, offset
 		})
 	})
 	if err != nil {
+		slog.Error("Search request failed", slog.String("query", query), slog.Any("error", err))
 		return nil, fmt.Errorf("search failed: %w", err)
 	}
-	return result.(*pb.SearchResponse), nil
+	resp := result.(*pb.SearchResponse)
+	slog.Info("Search request completed", slog.String("query", query), slog.Int("results", len(resp.Pages)))
+	return resp, nil
 }
 
 // CheckHealth checks if the Searcher service is healthy
@@ -74,6 +88,7 @@ func (c *SearcherClient) CheckHealth(ctx context.Context) (*pb.HealthResponse, e
 // Close closes the gRPC connection
 func (c *SearcherClient) Close() error {
 	if c.conn != nil {
+		slog.Info("Closing Searcher gRPC connection")
 		return c.conn.Close()
 	}
 	return nil

--- a/cmd/searcher/handler/server.go
+++ b/cmd/searcher/handler/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"webcrawler/cmd/searcher/tokeniser"
 	"webcrawler/pkg/generated/service/searcher"
@@ -24,8 +25,15 @@ func NewRPCServer(db *sql.DB) *Handler {
 func (c *Handler) SearchPages(ctx context.Context, request *searcher.SearchRequest) (*searcher.SearchResponse, error) {
 	tokens := tokeniser.Tokenise(request.GetQuery())
 
+	slog.Info("Search request received",
+		slog.String("query", request.GetQuery()),
+		slog.Int("tokens", len(tokens)),
+		slog.Int("limit", int(request.GetLimit())),
+		slog.Int("offset", int(request.GetOffset())))
+
 	// If no tokens, return empty response
 	if len(tokens) == 0 {
+		slog.Info("No tokens extracted from query, returning empty response", slog.String("query", request.GetQuery()))
 		return &searcher.SearchResponse{}, nil
 	}
 
@@ -65,6 +73,7 @@ func (c *Handler) SearchPages(ctx context.Context, request *searcher.SearchReque
 
 	rows, err := c.db.QueryContext(ctx, query, queryVector, limit, offset)
 	if err != nil {
+		slog.Error("Database query failed", slog.String("query", queryVector), slog.Any("error", err))
 		return nil, fmt.Errorf("failed to query pages: %w", err)
 	}
 	defer rows.Close()
@@ -82,6 +91,7 @@ func (c *Handler) SearchPages(ctx context.Context, request *searcher.SearchReque
 		var crawlTime sql.NullTime
 
 		if err := rows.Scan(&url, &title, &body, &description, &pagerankScore, &textRelevance, &combinedScore, &crawlTime); err != nil {
+			slog.Error("Failed to scan search result row", slog.Any("error", err))
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 
@@ -109,9 +119,11 @@ func (c *Handler) SearchPages(ctx context.Context, request *searcher.SearchReque
 	}
 
 	if err := rows.Err(); err != nil {
+		slog.Error("Error iterating search results", slog.Any("error", err))
 		return nil, fmt.Errorf("error iterating rows: %w", err)
 	}
 
+	slog.Info("Search completed", slog.String("query", request.GetQuery()), slog.Int("results", len(pages)))
 	return &searcher.SearchResponse{
 		Pages: pages,
 	}, nil
@@ -143,6 +155,8 @@ func (c *Handler) GetHealth(ctx context.Context, req *searcher.HealthRequest) (*
 
 	message := "searcher operational"
 	if pagerankCount == 0 {
+		slog.Warn("No PageRank data available, searcher operating in degraded mode",
+			slog.Int64("pagesIndexed", pagesCount))
 		message = "no PageRank data available (degraded)"
 	}
 


### PR DESCRIPTION
## Summary

- **Cartographer**: Added `log/slog` to `handler/flow.go` — logs sweep start, per-iteration site counts, PageRank/merge/push steps, and completion with sweep name
- **Searcher**: Added `log/slog` to `handler/server.go` — logs every query with token count, offset/limit, result count, plus errors on DB failures and degraded health (no PageRank data)
- **Frontend gRPC client**: Added `log/slog` to `grpc/client.go` — logs connection attempts, circuit breaker state transitions, per-query results, and connection close

## Why

All three services had zero logging instrumentation. In production, any failure or slow query would be invisible — no way to tell which sweep iteration failed, what queries were slow, or whether the circuit breaker was tripping.

## Test plan

- [x] `go build ./cmd/cartographer/... ./cmd/searcher/... ./cmd/frontend/...` — clean
- [x] `go test ./cmd/cartographer/... ./cmd/searcher/... ./cmd/frontend/...` — all pass