### PR TITLE
fix: safe search input handling and right-size CPU requests

### DIFF
--- a/cmd/searcher/handler/server.go
+++ b/cmd/searcher/handler/server.go
@@ -56,13 +56,13 @@ func (c *Handler) SearchPages(ctx context.Context, request *searcher.SearchReque
 			sp.body,
 			sp.description,
 			COALESCE(pr.score, 0.0) as pagerank_score,
-			ts_rank(sp.search_vector, to_tsquery('english', $1)) as text_relevance,
-			(ts_rank(sp.search_vector, to_tsquery('english', $1)) * 0.3 +
+			ts_rank(sp.search_vector, plainto_tsquery('english', $1)) as text_relevance,
+			(ts_rank(sp.search_vector, plainto_tsquery('english', $1)) * 0.3 +
 			 COALESCE(pr.score, 0.0) * 0.7) as combined_score,
 			sp.crawl_time
 		FROM seenpages sp
 		LEFT JOIN pagerankresults pr ON sp.id = pr.page_id AND pr.is_latest = true
-		WHERE sp.search_vector @@ to_tsquery('english', $1)
+		WHERE sp.search_vector @@ plainto_tsquery('english', $1)
 		  AND sp.is_indexable = true
 		ORDER BY combined_score DESC
 		LIMIT $2 OFFSET $3

--- a/deployments/conductor.yaml
+++ b/deployments/conductor.yaml
@@ -103,7 +103,7 @@ spec:
                   key: LOG_LEVEL
           resources:
             requests:
-              cpu: 500m
+              cpu: 150m
               memory: 512Mi
             limits:
               cpu: 2

--- a/deployments/searcher.yaml
+++ b/deployments/searcher.yaml
@@ -115,7 +115,7 @@ spec:
                   key: LOG_LEVEL
           resources:
             requests:
-              cpu: 450m
+              cpu: 150m
               memory: 256Mi
             limits:
               cpu: 2


### PR DESCRIPTION
## Summary
- Switches searcher from `to_tsquery` to `plainto_tsquery` so queries containing apostrophes, hyphens, or other special characters no longer cause a PostgreSQL syntax error and surface as "Search service unavailable" to users.
- Reduces over-provisioned CPU requests on searcher (450m → 150m) and conductor (500m → 150m) to reflect actual usage (~1m each), enabling the cluster to run on a single node without scheduling pressure.

## Test plan
- [ ] Search for terms with special characters (e.g. `claude's`, `llm-model`) and confirm results load without error
- [ ] Verify searcher and conductor pods schedule and run healthy on the single-node cluster
- [ ] Check HPA still scales correctly under load